### PR TITLE
MOB-3217 - Use nonce from response for Adyen booking

### DIFF
--- a/KarhooUISDK/Screens/BookingRequestScreen/FormBookingRequestScreen/FormBookingRequestPresenter.swift
+++ b/KarhooUISDK/Screens/BookingRequestScreen/FormBookingRequestScreen/FormBookingRequestPresenter.swift
@@ -58,8 +58,17 @@ final class FormBookingRequestPresenter: BookingRequestPresenter {
 
     private func getPaymentNonceAccordingToAuthState() -> String? {
         switch Karhoo.configuration.authenticationMethod() {
-        case .karhooUser, .tokenExchange(settings: _): return userService.getCurrentUser()?.nonce?.nonce
+        case .tokenExchange(settings: _): return tokenExchangeNonce()
+        case .karhooUser: return userService.getCurrentUser()?.nonce?.nonce
         default: return view?.getPaymentNonce()
+        }
+    }
+    
+    private func tokenExchangeNonce() -> String?{
+        if(userService.getCurrentUser()?.paymentProvider?.provider.type == .braintree) {
+            return userService.getCurrentUser()?.nonce?.nonce
+        } else {
+            return view?.getPaymentNonce()
         }
     }
 


### PR DESCRIPTION
## JIRA
[MOB-3217](https://karhoo.atlassian.net/browse/MOB-3217)

## DESCRIPTION
Use the nonce from the 3ds response for Adyen token exchange bookings

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix 
- [ ] New feature 
- [ ] Tech Debt
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Other: *define what type of change it is*

## CHECKLIST

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging code._
Please review the guidelines for contributing to this repository.

- [x] All work relating to the ticket is complete (Code complete/Acceptance Criteria met)
- [x] Lint and unit tests pass locally (if appropriate)
- [x] Added tests that prove the fix is effective or that feature works (if appropriate)
- [ ] Documentation (if appropriate)

## SCREENSHOTS
N/a
