### PR TITLE
MOB-3843: Add territory to passenger details locale

### DIFF
--- a/KarhooUISDK/CommonUI/UITexts.swift
+++ b/KarhooUISDK/CommonUI/UITexts.swift
@@ -72,6 +72,7 @@ public enum UITexts {
         public static let commentOptional = "Text.Generic.Comment.Optional".localized
         public static let optional = "Text.Generic.Optional".localized
         public static let errorMessage = "Text.Generic.ErrorMessage".localized
+        public static let locale = "Text.Generic.Locale".localized
     }
 
     public enum GenericTripStatus {

--- a/KarhooUISDK/Screens/PassengerDetails/PassengerDetailsViewController.swift
+++ b/KarhooUISDK/Screens/PassengerDetails/PassengerDetailsViewController.swift
@@ -37,7 +37,7 @@ final class PassengerDetailsViewController: UIViewController, BaseViewController
     private var inputViews = [KarhooInputView]()
     private var doneButtonBottomConstraint: NSLayoutConstraint!
     private var shouldMoveToNextInputViewOnReturn = true
-    private let currentLocale = NSLocale.current.languageCode ?? "en"
+    private let currentLocale = UITexts.Generic.locale
     
     // MARK: - Views and Controls
     private lazy var scrollView: UIScrollView = {

--- a/KarhooUISDK/Translations/Base.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/Base.lproj/Localizable.strings
@@ -463,7 +463,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Hide";
 
-"Text.Generic.Locale" = "en-GB";
+"Text.Generic.Locale" = "en_GB";
 
 "Text.Generic.Logout" = "Sign out";
 

--- a/KarhooUISDK/Translations/Base.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/Base.lproj/Localizable.strings
@@ -250,8 +250,6 @@
 "Text.Booking.QuoteExpiredMessage" = "Please select a new quote to continue with your booking";
 
 /* Booking */
-"Text.Booking.BookNow" = "BOOK NOW";
-
 "Text.Booking.RequestCar" = "PAY AND BOOK";
 
 "Text.Booking.RequestingCar" = "Booking Ride";
@@ -273,8 +271,6 @@
 
 /* used as a call to action on a button in the empty bookings screen: English: "Book Ride" */
 "Text.Bookings.BookATrip" = "Book Ride";
-
-"Text.Bookings.NewRide" = "NEW RIDE";
 
 /* "Cancel Ride" button action */
 "Text.Bookings.CancelRide" = "Cancel Ride";
@@ -466,6 +462,8 @@
 
 /* Password Entry Button */
 "Text.Generic.Hide" = "Hide";
+
+"Text.Generic.Locale" = "en-GB";
 
 "Text.Generic.Logout" = "Sign out";
 

--- a/KarhooUISDK/Translations/de.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/de.lproj/Localizable.strings
@@ -455,6 +455,8 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Ausblenden";
 
+"Text.Generic.Locale" = "de-DE";
+
 "Text.Generic.Logout" = "Abmeldung";
 
 /* english "making a booking". Used in terms conditions construction */

--- a/KarhooUISDK/Translations/de.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/de.lproj/Localizable.strings
@@ -455,7 +455,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Ausblenden";
 
-"Text.Generic.Locale" = "de-DE";
+"Text.Generic.Locale" = "de_DE";
 
 "Text.Generic.Logout" = "Abmeldung";
 

--- a/KarhooUISDK/Translations/es.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/es.lproj/Localizable.strings
@@ -455,7 +455,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Ocultar";
 
-"Text.Generic.Locale" = "es-ES";
+"Text.Generic.Locale" = "es_ES";
 
 "Text.Generic.Logout" = "Salir";
 

--- a/KarhooUISDK/Translations/es.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/es.lproj/Localizable.strings
@@ -455,6 +455,8 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Ocultar";
 
+"Text.Generic.Locale" = "es-ES";
+
 "Text.Generic.Logout" = "Salir";
 
 /* english "making a booking". Used in terms conditions construction */

--- a/KarhooUISDK/Translations/fr.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/fr.lproj/Localizable.strings
@@ -463,6 +463,8 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Masquer";
 
+"Text.Generic.Locale" = "fr-FR";
+
 "Text.Generic.Logout" = "Déconnexion";
 
 /* english "making a booking". Used in terms conditions construction */
@@ -643,7 +645,7 @@
 
 "Text.Quote.FreeCancellationAndKeyword" = "et";
 
-"Text.Quote.FreeCancellationASAP" = "Annulation sans frais jusqu'à %1$@ minutes après la réservation";
+"Text.Quote.FreeCancellationASAP" = "Annulation sans frais jusqu'à %1$@ après la réservation";
 
 "Text.Quote.FreeCancellationBeforeDriverEnRoute" = "Annulation sans frais jusqu'au départ du chauffeur";
 

--- a/KarhooUISDK/Translations/fr.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/fr.lproj/Localizable.strings
@@ -463,7 +463,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Masquer";
 
-"Text.Generic.Locale" = "fr-FR";
+"Text.Generic.Locale" = "fr_FR";
 
 "Text.Generic.Logout" = "Déconnexion";
 

--- a/KarhooUISDK/Translations/it.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/it.lproj/Localizable.strings
@@ -459,7 +459,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Nascondere";
 
-"Text.Generic.Locale" = "it-IT";
+"Text.Generic.Locale" = "it_IT";
 
 "Text.Generic.Logout" = "Esci";
 

--- a/KarhooUISDK/Translations/it.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/it.lproj/Localizable.strings
@@ -459,6 +459,8 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Nascondere";
 
+"Text.Generic.Locale" = "it-IT";
+
 "Text.Generic.Logout" = "Esci";
 
 /* english "making a booking". Used in terms conditions construction */

--- a/KarhooUISDK/Translations/nl.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/nl.lproj/Localizable.strings
@@ -463,7 +463,7 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Verbergen";
 
-"Text.Generic.Locale" = "nl-NL";
+"Text.Generic.Locale" = "nl_NL";
 
 "Text.Generic.Logout" = "Afmelden";
 

--- a/KarhooUISDK/Translations/nl.lproj/Localizable.strings
+++ b/KarhooUISDK/Translations/nl.lproj/Localizable.strings
@@ -463,6 +463,8 @@
 /* Password Entry Button */
 "Text.Generic.Hide" = "Verbergen";
 
+"Text.Generic.Locale" = "nl-NL";
+
 "Text.Generic.Logout" = "Afmelden";
 
 /* english "making a booking". Used in terms conditions construction */


### PR DESCRIPTION
## JIRA
[MOB-3843](https://karhoo.atlassian.net/browse/MOB-3843)

## DESCRIPTION
Add territory to passenger details locale. 
Read the locale from a localised string value to avoid issues with device/manufacturers, e.g. the device was reporting `fr_US` and for the backend the supported locale is `fr_FR` 

Agreed to follow similar approach on the Android as well

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [X] Bugfix 
- [ ] New feature 
- [ ] Tech Debt
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Other: *define what type of change it is*

## CHECKLIST

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging code._
Please review the guidelines for contributing to this repository.

- [X] All work relating to the ticket is complete (Code complete/Acceptance Criteria met)
- [ ] Lint and unit tests pass locally (if appropriate)
- [ ] Added tests that prove the fix is effective or that feature works (if appropriate)
- [ ] Documentation (if appropriate)

## SCREENSHOTS
[Add screenshots if any for changes you have made to the App/UI]
