### PR TITLE
Modify "Client" scheme to rebuilt UISDK when Client app is ran

### DIFF
--- a/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client+KarhooUISDK.xcscheme
+++ b/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client+KarhooUISDK.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC8F471321539E24007841FB"
+               BuildableName = "KarhooUISDK.framework"
+               BlueprintName = "KarhooUISDK"
+               ReferencedContainer = "container:KarhooUISDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5C2E260C2420F8AC00B1FF0C"
+               BuildableName = "Client.app"
+               BlueprintName = "Client"
+               ReferencedContainer = "container:KarhooUISDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C2E260C2420F8AC00B1FF0C"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:KarhooUISDK.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C2E260C2420F8AC00B1FF0C"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:KarhooUISDK.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FC8F471321539E24007841FB"
-               BuildableName = "KarhooUISDK.framework"
-               BlueprintName = "KarhooUISDK"
-               ReferencedContainer = "container:KarhooUISDK.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5C2E260C2420F8AC00B1FF0C"
                BuildableName = "Client.app"
                BlueprintName = "Client"

--- a/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/KarhooUISDK.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC8F471321539E24007841FB"
+               BuildableName = "KarhooUISDK.framework"
+               BlueprintName = "KarhooUISDK"
+               ReferencedContainer = "container:KarhooUISDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5C2E260C2420F8AC00B1FF0C"
                BuildableName = "Client.app"
                BlueprintName = "Client"


### PR DESCRIPTION
## DESCRIPTION
New build target added to `Client` scheme. This way every time you build/run Client the UISDK target will be rebuilt as well.

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix 
- [ ] New feature 
- [x] Tech Debt
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Other: *define what type of change it is*

## CHECKLIST

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging code._
Please review the guidelines for contributing to this repository.

- [ ] All work relating to the ticket is complete (Code complete/Acceptance Criteria met)
- [ ] Lint and unit tests pass locally (if appropriate)
- [ ] Added tests that prove the fix is effective or that feature works (if appropriate)
- [ ] Documentation (if appropriate)

## SCREENSHOTS
[Add screenshots if any for changes you have made to the App/UI]
